### PR TITLE
Reserve about-page image dimensions to fix pop-in

### DIFF
--- a/about/template.ejs
+++ b/about/template.ejs
@@ -2,7 +2,7 @@
 <div style="display:flex; flex-wrap: wrap;">
 <% for (const item of items) { %>
 <% if (item.team == "active") { %>
-<div style="margin: 0.5rem;"><a href="<%- item.url %>"><img style="width: 150px;" src="<%- item.photo %>"></a><br><p><%= item.title %></p></div>
+<div style="margin: 0.5rem;"><a href="<%- item.url %>"><img width="150" height="150" loading="lazy" decoding="async" style="width: 150px; height: 150px; object-fit: cover;" src="<%- item.photo %>" alt="<%= item.title %>"></a><br><p><%= item.title %></p></div>
 <% } %>
 <% } %>
 </div>
@@ -11,7 +11,7 @@
 <div style="display:flex; flex-wrap: wrap;">
 <% for (const item of items) { %>
 <% if (item.team == "past") { %>
-<div style="margin: 0.5rem;"><a href="<%- item.url %>"><img style="width: 150px;" src="<%- item.photo %>"></a><br><p><%= item.title %></p></div>
+<div style="margin: 0.5rem;"><a href="<%- item.url %>"><img width="150" height="150" loading="lazy" decoding="async" style="width: 150px; height: 150px; object-fit: cover;" src="<%- item.photo %>" alt="<%= item.title %>"></a><br><p><%= item.title %></p></div>
 <% } %>
 <% } %>
 </div>
@@ -21,7 +21,7 @@
 <div style="display:flex; flex-wrap: wrap;">
 <% for (const item of items) { %>
 <% if (item.team == "collaborators") { %>
-<div style="margin: 0.5rem;"><a href="<%- item.url %>"><img style="width: 150px;" src="<%- item.photo %>"></a><br><p><%= item.title %></p></div>
+<div style="margin: 0.5rem;"><a href="<%- item.url %>"><img width="150" height="150" loading="lazy" decoding="async" style="width: 150px; height: 150px; object-fit: cover;" src="<%- item.photo %>" alt="<%= item.title %>"></a><br><p><%= item.title %></p></div>
 <% } %>
 <% } %>
 </div>


### PR DESCRIPTION
## Summary
- Add explicit `width`/`height` plus `loading="lazy"`, `decoding="async"`, `object-fit: cover`, and `alt` text to author photos in `about/template.ejs`
- Browsers can now reserve the 150×150 slot before the image loads, eliminating the layout shift / pop-in reported in #237

Closes #237

## Test plan
- [x] Preview `/about/` locally and confirm photos no longer pop in
- [x] Re-run Lighthouse and verify CLS improvement