### PR TITLE
Install vip from GitHub while it is off CRAN

### DIFF
--- a/R/install_packages.R
+++ b/R/install_packages.R
@@ -17,9 +17,12 @@ install_packages <- function(needed) {
   cli::cli_alert_info("{length(needed)} package{?s} required: {.pkg {needed}}")
 
   # catboost must be installed from GitHub
+  # vip was archived from CRAN on 2026-07-08, so install it from GitHub
+  # temporarily until it returns to CRAN.
   # mixOmics must be excluded from the pak call and installed separately via
   # install.packages() — see comment below.
   to_install <- ifelse(needed == "catboost", "catboost/catboost/catboost/R-package", needed)
+  to_install <- ifelse(to_install == "vip", "bgreenwell/vip", to_install)
   to_install <- to_install[to_install != "mixOmics"]
 
   # pak's upgrade = TRUE upgrades ALL installed packages, not just those in


### PR DESCRIPTION
`vip` was archived from CRAN on 2026-07-08, which has broken the nightly automated re-render every day since (issues #300-#306). During the install step, pak's `upgrade = TRUE` re-resolves every installed package, including the archived `vip`; with no CRAN candidate it builds a resolution with an `NA` version and the solver's version comparison errors out (`missing value where TRUE/FALSE needed`), aborting the whole step before any page renders.

This requests `vip` as a GitHub ref (`bgreenwell/vip`) in `install_packages()`, mirroring the existing `catboost` handling, so pak resolves it against that remote instead. It's a temporary measure until vip returns to CRAN.